### PR TITLE
sv_parser.c: check packet size before copying

### DIFF
--- a/sv_parser.c
+++ b/sv_parser.c
@@ -73,6 +73,7 @@ int parse_SV_ASDU(const uint8_t *rawData, int rawDataLength, struct SV_ASDU *asd
                 length = rawData[cursor+1];
                 switch(tag) {
                 case 0x80: // svID
+                        if (unlikely(length > 34)) return BAD_FORMAT;
                         for (i = 0; i < length; ++i) {
                                 // start from 3rd byte
                                 asdu->svID[i] = rawData[cursor + i + 2];
@@ -81,6 +82,7 @@ int parse_SV_ASDU(const uint8_t *rawData, int rawDataLength, struct SV_ASDU *asd
                         cursor += length + 2;
                         break;
                 case 0x81: // datSet
+                        if (unlikely(length > 130)) return BAD_FORMAT;
                         for (i = 0; i < length; ++i) {
                                 // start from 3rd byte
                                 asdu->datSet[i] = rawData[cursor + i + 2];
@@ -119,6 +121,7 @@ int parse_SV_ASDU(const uint8_t *rawData, int rawDataLength, struct SV_ASDU *asd
                         cursor += length + 2;
                         break;
                 case 0x87: // sample
+                        if (unlikely(length > 64)) return BAD_FORMAT;
                         for (i = 0; i < length; ++i) {
                                 // start from 3rd byte
                                 asdu->seqData[i] = rawData[cursor + i + 2];
@@ -172,6 +175,8 @@ int parse_SV_payload(const uint8_t *payload, struct SV_payload *sv)
                         cursor += 2;
                         break;
                 case 0x30: // ASDU
+                        // 8 ASDU maximum in the standard
+                        if (unlikely(asdu_idx >= 8)) return BAD_FORMAT;
                         parse_SV_ASDU(&payload[cursor+2],
                                       length,
                                       &sv->seqASDU[asdu_idx]);

--- a/sv_parser.h
+++ b/sv_parser.h
@@ -10,6 +10,7 @@
 #include <stdint.h>
 
 #define BAD_FORMAT -1 /**< Error code when using a wrong sv payload */
+#define unlikely(x)     __builtin_expect(!!(x), 0)
 
 /**
  * \struct SV_ASDU


### PR DESCRIPTION
A buffer is used to store all the information of a packet after parsing. This buffer is only allocated once, to reduce execution time. It's size is determined by the maximum size of a packet in the IEC-61850 norm.

However, if a malformed too long packet is received, it could write outside of the buffer and lead to remote code execution. This commit fixes this issue by returning BAD_FORMAT in case of a too long packet. It also uses the unlikely C compiler feature to reduce the execution time overhead.